### PR TITLE
ci: fix travis bundler version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ sudo: false
 language: ruby
 rvm:
   - 2.5.0
-before_install: bundle install
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install -v 1.16.4 bundler --no-rdoc --no-ri
+  - bundle install
 cache: bundler
 script:
   - rspec


### PR DESCRIPTION
В тревисе поменяли дефолтную версию бандлера и старый конфиг [больше не собирается](https://travis-ci.org/sputnik8/atol-rb/builds/595828125?utm_source=github_status&utm_medium=notification
). Починил.

