### PR TITLE
fix get_token transaction

### DIFF
--- a/lib/atol/transaction/get_token.rb
+++ b/lib/atol/transaction/get_token.rb
@@ -12,7 +12,7 @@ module Atol
       end
 
       def call
-        @config.req_tries_number.times do |i|
+        @config.req_tries_number.times do
           request = Atol::Request::GetToken.new(config: @config)
           response = request.call
           encoded_body = response.body.dup.force_encoding(Atol::ENCODING)

--- a/spec/atol/transaction/get_token_spec.rb
+++ b/spec/atol/transaction/get_token_spec.rb
@@ -48,37 +48,51 @@ describe Atol::Transaction::GetToken do
       end
     end
 
-    context 'when response is 400' do
-      context 'when response body code 19' do
-        before do
-          stub_request(:get, /online.atol.ru/).to_return({
-            status: 400,
-            headers: {},
-            body: { code: 19 }.to_json
-          })
-          allow(Atol.config).to receive(:http_client).and_return(Net::HTTP)
-        end
-
-        it do
-          transaction = described_class.new(config: config)
-          expect { transaction.call }.to raise_error Atol::AuthUserOrPasswordError
-        end
+    context 'when response code is 400' do
+      before do
+        stub_request(:get, /online.atol.ru/).to_return({
+          status: 400,
+          headers: {},
+          body: { code: 17 }.to_json
+        })
+        allow(Atol.config).to receive(:http_client).and_return(Net::HTTP)
       end
 
-      context 'when response body code 17' do
-        before do
-          stub_request(:get, /online.atol.ru/).to_return({
-            status: 400,
-            headers: {},
-            body: { code: 17 }.to_json
-          })
-          allow(Atol.config).to receive(:http_client).and_return(Net::HTTP)
-        end
+      it do
+        transaction = described_class.new(config: config)
+        expect { transaction.call }.to raise_error Atol::AuthBadRequestError
+      end
+    end
 
-        it do
-          transaction = described_class.new(config: config)
-          expect { transaction.call }.to raise_error Atol::AuthBadRequestError
-        end
+    context 'when response code is 401' do
+      before do
+        stub_request(:get, /online.atol.ru/).to_return({
+          status: 401,
+          headers: {},
+          body: {}.to_json
+        })
+        allow(Atol.config).to receive(:http_client).and_return(Net::HTTP)
+      end
+
+      it do
+        transaction = described_class.new(config: config)
+        expect { transaction.call }.to raise_error Atol::AuthUserOrPasswordError
+      end
+    end
+
+    context 'when response code 415' do
+      before do
+        stub_request(:get, /online.atol.ru/).to_return({
+          status: 415,
+          headers: {},
+          body: {}.to_json
+        })
+        allow(Atol.config).to receive(:http_client).and_return(Net::HTTP)
+      end
+
+      it do
+        transaction = described_class.new(config: config)
+        expect { transaction.call }.to raise_error RuntimeError
       end
     end
   end


### PR DESCRIPTION
У АПИ протокола v4 Атол изменился код ошибки для WrongLoginOrPassword при получении Токена. Вызов Atol::Transaction::GetToken.new.call получал exception Undefined method response, т.к. в методе call переменная response недоступа за пределами итератора. 
```def call
        @config.req_tries_number.times do |i|
          request = Atol::Request::GetToken.new(config: @config)
          response = request.call
          encoded_body = response.body.encode(Atol::ENCODING)
          json = JSON.parse(encoded_body)

          case response.code
          when '200'
            return json['token']
          when '400'
            case json['code']
            when 19
              raise Atol::AuthUserOrPasswordError
            when 17
              raise Atol::AuthBadRequestError
            end
          when '500'
            next
          end
        end

        raise "#{response.code} #{response.body}"
      end
```
Также был переписан encoded_body на вызов метода force_encoding, потому-что в определенном случае метод encode может вызывать Encoding::UndefinedConversionError