### PR TITLE
build: update Gemfile.lock bundler version to 1.17.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,4 +80,4 @@ DEPENDENCIES
   webmock (~> 3.0)
 
 BUNDLED WITH
-   1.16.4
+   1.17.3


### PR DESCRIPTION
Уже никто не использует 1.16.4, у всех бандлер меняет эту строку