### PR TITLE
fix: cast item quantity to float before validation

### DIFF
--- a/lib/atol/request/post_document/item/body.rb
+++ b/lib/atol/request/post_document/item/body.rb
@@ -24,7 +24,7 @@ module Atol
           attr_accessor :config, :name, :price, :quantity, :payment_method, :payment_object
 
           def initialize(config: nil, name:, price:, quantity: 1, payment_method:, payment_object:)
-            raise Atol::ZeroItemQuantityError if quantity.to_i.zero?
+            raise Atol::ZeroItemQuantityError if quantity.to_f.zero?
             raise BadPaymentMethodError unless PAYMENT_METHODS.include?(payment_method.to_s)
             raise BadPaymentObjectError unless PAYMENT_OBJECTS.include?(payment_object.to_s)
 

--- a/spec/atol/request/post_document/item/body_spec.rb
+++ b/spec/atol/request/post_document/item/body_spec.rb
@@ -56,6 +56,16 @@ describe Atol::Request::PostDocument::Item::Body do
     end
   end
 
+  context 'when quantity less then 1 and more then 0' do
+    before do
+      params[:quantity] = 0.4
+    end
+
+    it 'inject qunatity' do
+      expect(body_hash[:quantity]).to eql 0.4
+    end
+  end
+
   context 'when bad payment_method given' do
     before { params[:payment_method] = 'bad payment method' }
 

--- a/spec/atol/request/post_document/item/body_spec.rb
+++ b/spec/atol/request/post_document/item/body_spec.rb
@@ -61,7 +61,7 @@ describe Atol::Request::PostDocument::Item::Body do
       params[:quantity] = 0.4
     end
 
-    it 'inject qunatity' do
+    it 'injects quantity' do
       expect(body_hash[:quantity]).to eql 0.4
     end
   end


### PR DESCRIPTION
При фискализации весового товара его количество может быть меньше 1, в коде же при проверке количества оно приводится к инту, в результате получается 0 и вызывается соовтественный экспепшн. Предлагаю приводить к флоату и потом уже проверять на ноль.  