### PR TITLE
fix: v5 supplier info without agent info

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # atol-rb
 
-Пакет содержит набор классов для работы с [KaaS-сервисом АТОЛ-онлайн](https://online.atol.ru/) по [описанному протоколу](https://atol.online/upload/iblock/dff/4yjidqijkha10vmw9ee1jjqzgr05q8jy/API_atol_online_v4.pdf).
+Пакет содержит набор классов для работы с [KaaS-сервисом АТОЛ-онлайн](https://online.atol.ru/) по описанному протоколу: [v4](https://atol.online/upload/iblock/dff/4yjidqijkha10vmw9ee1jjqzgr05q8jy/API_atol_online_v4.pdf) и [v5 (ФФД 1.2)](https://atol.online/upload/iblock/c23/q1o62ixkhvgxx413hpo0eaptkf6k5hrk/API%20%D1%81%D0%B5%D1%80%D0%B2%D0%B8%D1%81%D0%B0%20%D0%90%D0%A2%D0%9E%D0%9B%20%D0%9E%D0%BD%D0%BB%D0%B0%D0%B9%D0%BD_v5.pdf).
 
 ##### Совместимость
 
@@ -45,7 +45,7 @@ Rails.application.config.after_initialize do
     config.default_tax          = 'vat18'
     config.callback_url         = 'https://www.example.com/callback_path'
     config.company_email        = 'example@email.com'
-    config.default_payment_type = '1' # тэг 1031
+    config.default_payment_type = 1 # receipt.payments[].type: 0 — наличные (ФФД тег 1031), 1 — безналичные (ФФД тег 1081)
     config.api_url              = 'https://online.atol.ru/possystem/v5' # по умолчанию 'https://online.atol.ru/possystem/v4' ФФД 1.05
     config.internet             = true # тэг 1125, по умолчанию false
   end
@@ -62,7 +62,7 @@ URL тестовой среды необходимо указывать в ко�
 
 ```bash
 # .env
-ATOL_API_URL=https://testonline.atol.ru/possystem/v4
+ATOL_API_URL=https://testonline.atol.ru/possystem/v5
 ```
 
 > _Внимание! При создании чеков в тестовой среде АТОЛ будет отправлять письма на электронную почту покупателя._
@@ -108,13 +108,13 @@ body = Atol::Request::PostDocument::Sell::Body.new(
 ).to_json
 ```
 
-`agent_info_type` опциональный аргумент - признак агента (тег ФФД - 1057)
+`agent_info_type` — опциональный аргумент: признак агента по предмету расчёта (тег ФФД 1222).
 
 Массив `items` должен включать в себя объекты, которые так же соответствуют схеме.
 
 #### Items для версии V4
 
-Для создания `items` можно использовать класс `Atol::Request::PostDocument::Item::Body`.
+Для создания `items` можно использовать класс `Atol::Request::PostDocument::Item::Body` — он автоматически выбирает реализацию под v4/v5 по `config.api_url` (или `Atol.config.api_url`).
 
 Его конструктор принимает обязательные аргументы `name`, `price`, `payment_method`, `payment_object` и опциональные `quantity` (по умолчанию 1), `supplier_info_inn`, `supplier_info_name`, `agent_info_type` (тег ФФД - 1222).
 

--- a/lib/atol/request/post_document/item/v5/body.rb
+++ b/lib/atol/request/post_document/item/v5/body.rb
@@ -74,7 +74,7 @@ module Atol
             end
 
             def supplier_info
-              return if supplier_info_inn.nil? || supplier_info_inn.empty? || agent_info.nil?
+              return if supplier_info_inn.nil? || supplier_info_inn.empty?
 
               info = { inn: supplier_info_inn, name: supplier_info_name }
               filtered_info = info.reject { |_key, value| value&.empty? }

--- a/spec/lib/atol/request/post_document/item/v5/body_spec.rb
+++ b/spec/lib/atol/request/post_document/item/v5/body_spec.rb
@@ -130,6 +130,9 @@ RSpec.describe Atol::Request::PostDocument::Item::V5::Body do
   context "when agent_info_type nil" do
     before { params[:agent_info_type] = nil }
 
-    it { expect(body_hash[:supplier_info]).to be_nil }
+    it 'omits agent_info but includes supplier_info', :aggregate_failures do
+      expect(body_hash).not_to have_key(:agent_info)
+      expect(body_hash[:supplier_info]).to eq(inn: '10101964', name: "ООО 'Моя Оборона'")
+    end
   end
 end


### PR DESCRIPTION
## Что сделано
- В ATOL v5 разрешена передача `supplier_info` в позиции чека **без** обязательного `agent_info`.
- Убрана искусственная зависимость в `Atol::Request::PostDocument::Item::V5::Body`: раньше `supplier_info` не попадал в payload, если не был задан `agent_info_type`.
## Изменения
- `lib/atol/request/post_document/item/v5/body.rb`: `supplier_info` формируется по наличию `supplier_info_inn` (без проверки на `agent_info`).
- `spec/lib/atol/request/post_document/item/v5/body_spec.rb`: обновлён тест для случая `agent_info_type = nil` — `supplier_info` есть, `agent_info` отсутствует.
- `README.md`: поправлены ссылки/пояснения для v5 и теги для `default_payment_type` (1031 наличные / 1081 безналичные), уточнён тег для `agent_info_type`.
## Зачем
Документация ATOL v5 допускает `supplier_info` независимо от `agent_info`, а текущая реализация гема это блокировала.
